### PR TITLE
Updating to use the jenkins copy api.

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
@@ -49,9 +49,15 @@ class JenkinsApi {
         response.data.text
     }
 
-    void cloneJobForBranch(ConcreteJob missingJob, List<TemplateJob> templateJobs) {
+    void cloneJobForBranch(ConcreteJob missingJob, List<TemplateJob> templateJobs) 
+    {
         String missingJobConfig = configForMissingJob(missingJob, templateJobs)
-        post('createItem', missingJobConfig, [name: missingJob.jobName], ContentType.XML)
+        TemplateJob templateJob = missingJob.templateJob
+
+        //Copy job with jenkins copy job api, this will make sure jenkins plugins get the call to make a copy if needed (promoted builds plugin needs this)
+        post('createItem', missingJobConfig, [name: missingJob.jobName,mode: 'copy', from:templateJob.jobName], ContentType.XML)
+
+        post('job/'+missingJob.jobName+"/config.xml",missingJobConfig,[:],ContentType.XML)
     }
 
     String configForMissingJob(ConcreteJob missingJob, List<TemplateJob> templateJobs) {


### PR DESCRIPTION
Some Jenkins plugins do not keep their config in the config.xml meaning they can't be updated via the API, one example is the promoted builds plugin. There is an internal job copy that will trigger a call to those type of plugins. 

I changed the cloneJobForBranch to call the copy method in the jenkins api and then update the config.xml of the copy.

The only draw back to this approach is any job name updates that are not in the config.xml will not be done and I don't know that there is a way to fix that issue.
