### PR TITLE
Specifying `branchNameRegex` throws an exception

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -148,7 +148,7 @@ class JenkinsJobManager {
     GitApi initGitApi() {
         if (!gitApi) {
             assert gitUrl != null
-            this.gitApi = new GitApi(gitUrl: gitUrl, branchNameFilter: this.branchNameRegex)
+            this.gitApi = new GitApi(gitUrl: gitUrl, branchNameFilter: ~this.branchNameRegex)
         }
 
         return this.gitApi


### PR DESCRIPTION
Whenever a -DbranchNameRegex parameter is supplied, an exception is thrown.

``````
Exception in thread "main" org.codehaus.groovy.runtime.typehandling.GroovyCastException:
 Cannot cast object 'feature' with class 'java.lang.String' to class 'java.util.regex.Pattern'
    at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType(DefaultTypeTransformation.java:360)
    at groovy.lang.MetaClassImpl.setProperty(MetaClassImpl.java:2374)
    at groovy.lang.MetaClassImpl.setProperty(MetaClassImpl.java:3312)
    at groovy.lang.MetaClassImpl.setProperties(MetaClassImpl.java:1477)
    at org.codehaus.groovy.runtime.callsite.ConstructorSite$NoParamSite.callConstructor(ConstructorSite.java:122)
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:54)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:182)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:190)
    at com.entagen.jenkins.JenkinsJobManager.initGitApi(JenkinsJobManager.groovy:151)
    at com.entagen.jenkins.JenkinsJobManager.<init>(JenkinsJobManager.groovy:25)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:44)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:27)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:516)
    at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:77)
    at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:102)
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:54)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:182)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:190)
    at com.entagen.jenkins.Main.main(Main.groovy:25)```
``````
