### PR TITLE
only set branchNameRegex if supplied

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -148,7 +148,10 @@ class JenkinsJobManager {
     GitApi initGitApi() {
         if (!gitApi) {
             assert gitUrl != null
-            this.gitApi = new GitApi(gitUrl: gitUrl, branchNameFilter: ~this.branchNameRegex)
+            this.gitApi = new GitApi(gitUrl: gitUrl)
+            if (this.branchNameRegex){
+                this.gitApi.branchNameFilter = ~this.branchNameRegex
+            }
         }
 
         return this.gitApi

--- a/src/test/groovy/com/entagen/jenkins/JenkinsJobManagerTests.groovy
+++ b/src/test/groovy/com/entagen/jenkins/JenkinsJobManagerTests.groovy
@@ -40,4 +40,15 @@ class JenkinsJobManagerTests extends GroovyTestCase {
         assert "myproj-foo-myfeature" == templateJob.jobNameForBranch("myfeature")
         assert "myproj-foo-ted_myfeature" == templateJob.jobNameForBranch("ted/myfeature")
     }
+
+
+    @Test public void testInitGitApi_noBranchRegex() {
+        JenkinsJobManager jenkinsJobManager = new JenkinsJobManager(gitUrl: "git@dummy.com:company/myproj.git", jenkinsUrl: "http://dummy.com")
+        assert jenkinsJobManager.gitApi
+    }
+
+    @Test public void testInitGitApi_withBranchRegex() {
+        JenkinsJobManager jenkinsJobManager = new JenkinsJobManager(gitUrl: "git@dummy.com:company/myproj.git", branchNameRegex: 'feature\\/.+|release\\/.+|master', jenkinsUrl: "http://dummy.com")
+        assert jenkinsJobManager.gitApi
+    }
 }


### PR DESCRIPTION
#15 fixed an issue when branchNameRegex is supplied, but broke things when a branchNameRegex _isn't_ supplied
