### PR TITLE
Branches with a suffix of templateBranchName will create a new, valid job template. Then creates many new jobs.

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -90,7 +90,7 @@ class JenkinsJobManager {
     }
 
     List<TemplateJob> findRequiredTemplateJobs(List<String> allJobNames) {
-        String regex = /^($templateJobPrefix-.*)-($templateBranchName)$/
+        String regex = /^($templateJobPrefix-[^-]*)-($templateBranchName)$/
 
         List<TemplateJob> templateJobs = allJobNames.findResults { String jobName ->
             TemplateJob templateJob = null


### PR DESCRIPTION
A newly pushed branch with the right name, will cause the script to create a new template-driven job, as it should. But this new job could also match the naming requirements for a "TemplateJob". 

Thus the script thinks you added a new TemplateJob, and the next time it is called, will create a new set of template-driven jobs, using that new TemplateJob. If unchecked, it's possible that the badly-named branch will create a 2nd new TemplateJob and set of template-driven jobs, repeating the cycle!
### Steps to reproduce

I have set up the script with these parameters:
- templateJobPrefix: `MyProject`
- templateBranchName: `master`
- one job template: `MyProject-runTests-master`

Then I pushed up a new branch `judo-master`, then ran the script.

This creates a new job, `MyProject-runTests-judo-master`.

Then the second time the script is called, and it appears that the new job is being used as a TemplateJob. I will see `MyProject-runTests-judo-mybranch` and more, with the base job name being `MyProject-runTests-judo-`.
### Fix

Since "-" is used to delimit the 3 meaningful sections (`MyProject`, `runTests`, `branchname`) of the full job name, it should be restricted as much as possible. We don't want to set limits on branch names, and "-" is commonly used, so suggest we do not allow use in the 1st section (`MyProject`) and 2nd section (`runTests`). That means we can safely split on the two left-most  "-" we find in the string.

The change has been tested to work against our instance of this issue.
