### PR TITLE
Properly handle template branch names that contain a forward slash

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -1,7 +1,5 @@
 package com.entagen.jenkins
 
-import java.util.regex.Pattern
-
 class JenkinsJobManager {
     String templateJobPrefix
     String templateBranchName
@@ -94,12 +92,13 @@ class JenkinsJobManager {
     }
 
     List<TemplateJob> findRequiredTemplateJobs(List<String> allJobNames) {
-        String regex = /^($templateJobPrefix-[^-]*)-($templateBranchName)$/
+        def templateBranchJobName = templateBranchName.replaceAll('/', '_')
+        String regex = /^($templateJobPrefix-[^-]*)-($templateBranchJobName)$/
 
         List<TemplateJob> templateJobs = allJobNames.findResults { String jobName ->
             TemplateJob templateJob = null
             jobName.find(regex) { full, baseJobName, branchName ->
-                templateJob = new TemplateJob(jobName: full, baseJobName: baseJobName, templateBranchName: branchName)
+                templateJob = new TemplateJob(jobName: full, baseJobName: baseJobName, templateBranchName: templateBranchName)
             }
             return templateJob
         }

--- a/src/test/groovy/com/entagen/jenkins/JenkinsJobManagerTests.groovy
+++ b/src/test/groovy/com/entagen/jenkins/JenkinsJobManagerTests.groovy
@@ -19,6 +19,22 @@ class JenkinsJobManagerTests extends GroovyTestCase {
     }
 
 
+    @Test public void testFindTemplateJobs_withSlash() {
+        JenkinsJobManager jenkinsJobManager = new JenkinsJobManager(templateJobPrefix: "myproj", templateBranchName: "my/slashed/branch", jenkinsUrl: "http://dummy.com", gitUrl: "git@dummy.com:company/myproj.git")
+        List<String> allJobNames = [
+                "myproj-foo-my_slashed_branch",
+                "otherproj-foo-master",
+                "myproj-foo-featurebranch"
+        ]
+        List<TemplateJob> templateJobs = jenkinsJobManager.findRequiredTemplateJobs(allJobNames)
+        assert templateJobs.size() == 1
+        TemplateJob templateJob = templateJobs.first()
+        assert templateJob.jobName == "myproj-foo-my_slashed_branch"
+        assert templateJob.baseJobName == "myproj-foo"
+        assert templateJob.templateBranchName == "my/slashed/branch"
+    }
+
+
     @Test public void testFindTemplateJobs_noMatchingJobsThrowsException() {
         JenkinsJobManager jenkinsJobManager = new JenkinsJobManager(templateJobPrefix: "myproj", templateBranchName: "master", jenkinsUrl: "http://dummy.com", gitUrl: "git@dummy.com:company/myproj.git")
         List<String> allJobNames = [


### PR DESCRIPTION
If the `templateBranchName` is a branch containing a forward slash (e.g. `dev/v1.0`) this leads to errors when trying to retrieve the job's config from Jenkins (since Jenkins interprets the `/` as part of the URL and therefore throws a 404). This PR runs the `templateBranchName` through the same conversion (`/` -> `_`) as the job names created from git branches. Thus, for a `templateBranchName` like the above example, the expected name of the template **job** is `dev_v1.0`, matching the general pattern the script expects.
