### PR TITLE
clone: clones of disabled jobs now stay disabled

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
@@ -59,9 +59,12 @@ class JenkinsApi {
         post('createItem', missingJobConfig, [name: missingJob.jobName, mode: 'copy', from: templateJob.jobName], ContentType.XML)
 
         post('job/' + missingJob.jobName + "/config.xml", missingJobConfig, [:], ContentType.XML)
-        //Forced diable enable to work around Jenkins' automatic disabling of clones jobs
+        //Forced disable enable to work around Jenkins' automatic disabling of clones jobs
+        //But only if the original job was enabled
         post('job/' + missingJob.jobName + '/disable')
-        post('job/' + missingJob.jobName + '/enable')
+        if (!missingJobConfig.contains("<disabled>true</disabled>")) {
+            post('job/' + missingJob.jobName + '/enable')
+        }
     }
 
     void startJob(ConcreteJob job) {


### PR DESCRIPTION
Had an issue with disabled jobs that got enabled upon clone.
This commit should keep disabled jobs disabled.
I'm not a big groovy expert so this minimal comparison is probably not the best way to analyze the config. But it works for me... And I guess the principle here is important.

Thanks for all the effort!
Yonatan
