### PR TITLE
Fix groovy dependency resolution error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,11 @@ repositories {
 }
 
 dependencies {
-    groovy 'org.codehaus.groovy:groovy-all:1.8.6'
+    groovy 'org.codehaus.groovy:groovy-all:1.8.8'
     compile 'org.apache.ivy:ivy:2.2.0'
     compile 'commons-cli:commons-cli:1.2' // should be part of groovy, but not available when running for some reason
     testCompile 'junit:junit:4.10'
-    compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.5.2'
+    compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
 }
 
 task createSourceDirs(description : 'Create empty source directories for all defined sourceSets') << {


### PR DESCRIPTION
This PR is a fix for #55. I simply upgraded Http-Builder from 0.5.2 to 0.7.1. The old version had a dependency on Groovy 1.5 or 1.7.99, neither of which appeared to be in MavenCentral anymore. 

The new version uses groovy 1.8.8, so I updated the gradle build script to also use 1.8.8 just to clean things up a bit. 

Tested on Entagen build servers
