### PR TITLE
printConfig doesn't exit

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/Main.groovy
+++ b/src/main/groovy/com/entagen/jenkins/Main.groovy
@@ -44,7 +44,6 @@ class Main {
 
         if (argsMap.printConfig) {
             showConfiguration(argsMap)
-            System.exit(0)
         }
 
         def missingArgs = opts.findAll { shortOpt, optMap ->


### PR DESCRIPTION
I was quite confused as to why there is no command running, until I noticed that `-DprintConfig=true` basically exits after printing the configuration

Is there any reason to exit after printing the configuration?
It's good to log configuration + process output, so both should work in the same job run.
