### PR TITLE
Regex branch fix

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
@@ -108,7 +108,7 @@ class JenkinsApi {
         println "creating view - viewName:${viewName}, nestedView:${nestedWithinView}"
         post(buildViewPath("createView", nestedWithinView), body)
 
-        String regex = viewRegex ?: "${branchView.templateJobPrefix}.*${branchView.safeBranchName}"
+        String regex = viewRegex ? viewRegex.replaceAll("master", branchView.safeBranchName) : "${branchView.templateJobPrefix}.*${branchView.safeBranchName}"
         body = [useincluderegex: 'on', includeRegex: regex, name: viewName, json: '{"name": "' + viewName + '","useincluderegex": {"includeRegex": "' + regex + '"},' + VIEW_COLUMNS_JSON + '}']
         println "configuring view ${viewName}"
         post(buildViewPath("configSubmit", nestedWithinView, viewName), body)


### PR DESCRIPTION
Fixes an issue where a custom regex wouldn't get the "master" branch name substituted for the actual branch name, so any generated views would still only show the "master" jobs.
