### PR TITLE
Maven build as an alternative to Gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ build
 
 out
 atlassian-ide-plugin.xml
+
+.idea/
+*.iml
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.entagen.jenkins</groupId>
+    <artifactId>jenkins-build-per-branch</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.source-target.version>1.6</java.source-target.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- Redundantly add this plugin in order to make goals such as dependency:analyze and
+                     dependency:tree clickable from IntelliJ IDEA Maven view. -->
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.8</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>addSources</goal>
+                            <goal>addTestSources</goal>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
+                    <targetBytecode>${java.source-target.version}</targetBytecode>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.entagen.jenkins.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.1</version>
+        </dependency>
+        <dependency>
+            <!-- Contained in groovy-all, but not supposed to be used during runtime,
+                 see https://jira.codehaus.org/browse/GROOVY-6534 -->
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy.modules.http-builder</groupId>
+            <artifactId>http-builder</artifactId>
+            <version>0.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.json-lib</groupId>
+            <artifactId>json-lib</artifactId>
+            <version>2.4</version>
+            <classifier>jdk15</classifier>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/groovy/com/entagen/jenkins/GitApiTest.groovy
+++ b/src/test/groovy/com/entagen/jenkins/GitApiTest.groovy
@@ -2,7 +2,7 @@ package com.entagen.jenkins
 
 import org.junit.Test
 
-class GitApiTests extends GroovyTestCase {
+class GitApiTest extends GroovyTestCase {
 
     @Test public void testEachResultLine_goodCommand() {
         GitApi gitApi = new GitApi()
@@ -78,16 +78,14 @@ abd856d2ae658ee5f14889b465f3adcaf65fb52b\trefs/heads/other_branch
         assert ["feature/myfeature"] == branchNames.sort()
     }
 
-}
+    static class GitApiMockedResult extends GitApi {
+        String mockResult = "mock result"
 
-
-class GitApiMockedResult extends GitApi {
-    String mockResult = "mock result"
-
-    @Override
-    void eachResultLine(String command, Closure closure) {
-        mockResult.eachLine { String line ->
-            closure(line)
+        @Override
+        void eachResultLine(String command, Closure closure) {
+            mockResult.eachLine { String line ->
+                closure(line)
+            }
         }
     }
 }

--- a/src/test/groovy/com/entagen/jenkins/JenkinsApiReadOnlyTest.groovy
+++ b/src/test/groovy/com/entagen/jenkins/JenkinsApiReadOnlyTest.groovy
@@ -3,7 +3,7 @@ package com.entagen.jenkins
 import org.junit.Test
 import org.apache.http.HttpStatus
 
-class JenkinsApiReadOnlyTests extends GroovyTestCase {
+class JenkinsApiReadOnlyTest extends GroovyTestCase {
     @Test public void testAllReadOnlyPostsReturnOK() {
         JenkinsApi api = new JenkinsApiReadOnly(jenkinsServerUrl: "http://localhost:9090/jenkins")
         assert api.post("http://foo.com") == HttpStatus.SC_OK

--- a/src/test/groovy/com/entagen/jenkins/JenkinsApiTest.groovy
+++ b/src/test/groovy/com/entagen/jenkins/JenkinsApiTest.groovy
@@ -8,7 +8,7 @@ import groovyx.net.http.RESTClient
 import net.sf.json.JSON
 import net.sf.json.JSONObject
 
-class JenkinsApiTests extends GroovyTestCase {
+class JenkinsApiTest extends GroovyTestCase {
 
     @Test public void testInvalidHostThrowsConnectionException() {
         JenkinsApi api = new JenkinsApi(jenkinsServerUrl: "http://some-invalid-hostname:9090/jenkins")
@@ -115,7 +115,4 @@ class JenkinsApiTests extends GroovyTestCase {
             closure()
         }
     }
-
-
 }
-

--- a/src/test/groovy/com/entagen/jenkins/JenkinsJobManagerTest.groovy
+++ b/src/test/groovy/com/entagen/jenkins/JenkinsJobManagerTest.groovy
@@ -2,7 +2,7 @@ package com.entagen.jenkins
 
 import org.junit.Test
 
-class JenkinsJobManagerTests extends GroovyTestCase {
+class JenkinsJobManagerTest extends GroovyTestCase {
     @Test public void testFindTemplateJobs() {
         JenkinsJobManager jenkinsJobManager = new JenkinsJobManager(templateJobPrefix: "myproj", templateBranchName: "master", jenkinsUrl: "http://dummy.com", gitUrl: "git@dummy.com:company/myproj.git")
         List<String> allJobNames = [
@@ -18,7 +18,6 @@ class JenkinsJobManagerTests extends GroovyTestCase {
         assert templateJob.templateBranchName == "master"
     }
 
-
     @Test public void testFindTemplateJobs_noMatchingJobsThrowsException() {
         JenkinsJobManager jenkinsJobManager = new JenkinsJobManager(templateJobPrefix: "myproj", templateBranchName: "master", jenkinsUrl: "http://dummy.com", gitUrl: "git@dummy.com:company/myproj.git")
         List<String> allJobNames = [
@@ -32,15 +31,12 @@ class JenkinsJobManagerTests extends GroovyTestCase {
         assert result == "Unable to find any jobs matching template regex: ^(myproj-[^-]*)-(master)\$\nYou need at least one job to match the templateJobPrefix and templateBranchName suffix arguments. Expression: (templateJobs?.size() > 0)"
     }
 
-
-
     @Test public void testTemplateJobSafeNames() {
         TemplateJob templateJob = new TemplateJob(jobName: "myproj-foo-master", baseJobName: "myproj-foo", templateBranchName: "master")
 
         assert "myproj-foo-myfeature" == templateJob.jobNameForBranch("myfeature")
         assert "myproj-foo-ted_myfeature" == templateJob.jobNameForBranch("ted/myfeature")
     }
-
 
     @Test public void testInitGitApi_noBranchRegex() {
         JenkinsJobManager jenkinsJobManager = new JenkinsJobManager(gitUrl: "git@dummy.com:company/myproj.git", jenkinsUrl: "http://dummy.com")


### PR DESCRIPTION
Hi.

I had problems building with Gradle here in my firewalled environment. Also, I am a total Gradle noob. Thus I decided to create a clean Maven build from scratch for your project. See my commit comments for further information. Maybe you even want to consider publishing your plugin on Maven Central as a service to your users. That way it would not be necessary anymore to use Gradle on the Jenkins server (this led to raised eyebrows from our admins) and compile the project on the fly.

Kind regards
Alexander Kriegisch