### PR TITLE
Some minor alterations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ task syncWithRepo(dependsOn: 'classes', type: JavaExec) {
     main = 'com.entagen.jenkins.Main'
     classpath = sourceSets.main.runtimeClasspath
     // pass through specified system properties to the call to main
-    ['help', 'jenkinsUrl', 'jenkinsUser', 'jenkinsPassword', 'gitUrl', 'templateJobPrefix', 'templateBranchName', 'branchNameRegex', 'nestedView', 'viewRegex', 'printConfig', 'dryRun', 'startOnCreate', 'noViews', 'noDelete'].each {
+    ['help', 'jenkinsUrl', 'jenkinsUser', 'jenkinsPassword', 'gitUrl', 'templateJobPrefix', 'templateBranchName', 'branchNameRegex', 'nestedView', 'viewRegex', 'printConfig', 'dryRun', 'startOnCreate', 'startExpected', 'noViews', 'noDelete'].each {
         if (System.getProperty(it)) systemProperty it, System.getProperty(it)
     }
 

--- a/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
@@ -60,11 +60,8 @@ class JenkinsApi {
 
         post('job/' + missingJob.jobName + "/config.xml", missingJobConfig, [:], ContentType.XML)
         //Forced disable enable to work around Jenkins' automatic disabling of clones jobs
-        //But only if the original job was enabled
         post('job/' + missingJob.jobName + '/disable')
-  //      if (!missingJobConfig.contains("<disabled>true</disabled>")) {
-            post('job/' + missingJob.jobName + '/enable')
-  //      }
+        post('job/' + missingJob.jobName + '/enable')
     }
 
     void startJob(ConcreteJob job) {

--- a/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
@@ -62,9 +62,9 @@ class JenkinsApi {
         //Forced disable enable to work around Jenkins' automatic disabling of clones jobs
         //But only if the original job was enabled
         post('job/' + missingJob.jobName + '/disable')
-        if (!missingJobConfig.contains("<disabled>true</disabled>")) {
+  //      if (!missingJobConfig.contains("<disabled>true</disabled>")) {
             post('job/' + missingJob.jobName + '/enable')
-        }
+  //      }
     }
 
     void startJob(ConcreteJob job) {

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -47,6 +47,7 @@ class JenkinsJobManager {
     public void syncJobs(List<String> allBranchNames, List<String> allJobNames, List<TemplateJob> templateJobs) {
         List<String> currentTemplateDrivenJobNames = templateDrivenJobNames(templateJobs, allJobNames)
         List<String> nonTemplateBranchNames = allBranchNames - templateBranchName
+        println "nonTemplateBranchNames: ${nonTemplateBranchNames}"
         List<ConcreteJob> expectedJobs = this.expectedJobs(templateJobs, nonTemplateBranchNames)
 
         createMissingJobs(expectedJobs, currentTemplateDrivenJobNames, templateJobs)
@@ -109,13 +110,11 @@ class JenkinsJobManager {
                 templateJob = new TemplateJob(jobName: full, baseJobName: baseJobName, templateBranchName: branchName)
             }
 
-            println "templateJob: $templateJob for $jobName"
             return templateJob
         }
 
         assert templateJobs?.size() > 0, "Unable to find any jobs matching template regex: $regex\nYou need at least one job to match the templateJobPrefix and templateBranchName suffix arguments"
 
-        println "templateJobs: $templateJobs"
         return templateJobs
     }
 

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -79,7 +79,7 @@ class JenkinsJobManager {
             if (!noDelete && jobName.matches(branchNameRegex)) {
                 println "Deleting deprecated job: $jobName"
                 jenkinsApi.deleteJob(jobName)
-            } else if (jobName.matches(branchNameRegex)) {
+            } else if (!jobName.matches(branchNameRegex)) {
                 println "Will not delete job: $jobName because it dos not comply to the branchNameRegex $branchNameRegex"
             } else {
                 println "Would have deleted: $jobName but noDelete is set"

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -109,7 +109,7 @@ class JenkinsJobManager {
                 templateJob = new TemplateJob(jobName: full, baseJobName: baseJobName, templateBranchName: branchName)
             }
 
-            println "templateJob: $templateJob for $jobName"
+            println "templateJob: $templateJob.jobName $templateJob.baseJobName $templateJob.templateBranchNamefor $jobName"
             return templateJob
         }
 

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -109,7 +109,7 @@ class JenkinsJobManager {
                 templateJob = new TemplateJob(jobName: full, baseJobName: baseJobName, templateBranchName: branchName)
             }
 
-            println "templateJob: $templateJob.jobName $templateJob.baseJobName $templateJob.templateBranchNamefor $jobName"
+            println "templateJob: $templateJob for $jobName"
             return templateJob
         }
 

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -51,11 +51,7 @@ class JenkinsJobManager {
         List<ConcreteJob> expectedJobs = this.expectedJobs(templateJobs, nonTemplateBranchNames)
 
         createMissingJobs(expectedJobs, currentTemplateDrivenJobNames, templateJobs)
-        if (!noDelete) {
-            deleteDeprecatedJobs(currentTemplateDrivenJobNames - expectedJobs.jobName)
-        } else {
-            println "Would have deleted: ${currentTemplateDrivenJobNames - expectedJobs.jobName}"
-        }
+        deleteDeprecatedJobs(currentTemplateDrivenJobNames - expectedJobs.jobName)
         if (startExpected) {
             for (ConcreteJob expectedJob : expectedJobs) {
                 jenkinsApi.startJob(expectedJob)
@@ -79,9 +75,15 @@ class JenkinsJobManager {
 
     public void deleteDeprecatedJobs(List<String> deprecatedJobNames) {
         if (!deprecatedJobNames) return
-        println "Deleting deprecated jobs:\n\t${deprecatedJobNames.join('\n\t')}"
         deprecatedJobNames.each { String jobName ->
-            jenkinsApi.deleteJob(jobName)
+            if (!noDelete && jobName.matches(branchNameRegex)) {
+                println "Deleting deprecated job: $jobName"
+                jenkinsApi.deleteJob(jobName)
+            } else if (jobName.matches(branchNameRegex)) {
+                println "Will not delete job: $jobName because it dos not comply to the branchNameRegex $branchNameRegex"
+            } else {
+                println "Would have deleted: $jobName but noDelete is set"
+            }
         }
     }
 

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -47,7 +47,6 @@ class JenkinsJobManager {
     public void syncJobs(List<String> allBranchNames, List<String> allJobNames, List<TemplateJob> templateJobs) {
         List<String> currentTemplateDrivenJobNames = templateDrivenJobNames(templateJobs, allJobNames)
         List<String> nonTemplateBranchNames = allBranchNames - templateBranchName
-        println "nonTemplateBranchNames: ${nonTemplateBranchNames}"
         List<ConcreteJob> expectedJobs = this.expectedJobs(templateJobs, nonTemplateBranchNames)
 
         createMissingJobs(expectedJobs, currentTemplateDrivenJobNames, templateJobs)

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -108,6 +108,8 @@ class JenkinsJobManager {
             jobName.find(regex) { full, baseJobName, branchName ->
                 templateJob = new TemplateJob(jobName: full, baseJobName: baseJobName, templateBranchName: branchName)
             }
+
+            println "templateJob: $templateJob for $jobName"
             return templateJob
         }
 

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -101,7 +101,7 @@ class JenkinsJobManager {
     }
 
     List<TemplateJob> findRequiredTemplateJobs(List<String> allJobNames) {
-        String regex = /^($templateJobPrefix-[^-]*)-($templateBranchName)$/
+        String regex = /^($templateJobPrefix-?[^-]*)-($templateBranchName)$/
 
         List<TemplateJob> templateJobs = allJobNames.findResults { String jobName ->
             TemplateJob templateJob = null

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -114,6 +114,8 @@ class JenkinsJobManager {
         }
 
         assert templateJobs?.size() > 0, "Unable to find any jobs matching template regex: $regex\nYou need at least one job to match the templateJobPrefix and templateBranchName suffix arguments"
+
+        println "templateJobs: $templateJobs"
         return templateJobs
     }
 

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -1,7 +1,5 @@
 package com.entagen.jenkins
 
-import java.util.regex.Pattern
-
 class JenkinsJobManager {
     String templateJobPrefix
     String templateBranchName
@@ -17,6 +15,7 @@ class JenkinsJobManager {
     Boolean noViews = false
     Boolean noDelete = false
     Boolean startOnCreate = false
+    Boolean startExpected = false
 
     JenkinsApi jenkinsApi
     GitApi gitApi
@@ -54,6 +53,11 @@ class JenkinsJobManager {
         if (!noDelete) {
             deleteDeprecatedJobs(currentTemplateDrivenJobNames - expectedJobs.jobName)
         }
+        if (startExpected) {
+            for (ConcreteJob expectedJob : expectedJobs) {
+                jenkinsApi.startJob(expectedJob)
+            }
+        }
     }
 
     public void createMissingJobs(List<ConcreteJob> expectedJobs, List<String> currentJobs, List<TemplateJob> templateJobs) {
@@ -63,7 +67,7 @@ class JenkinsJobManager {
         for(ConcreteJob missingJob in missingJobs) {
             println "Creating missing job: ${missingJob.jobName} from ${missingJob.templateJob.jobName}"
             jenkinsApi.cloneJobForBranch(missingJob, templateJobs)
-            if (startOnCreate) {
+            if (startOnCreate && !startExpected) {
                 jenkinsApi.startJob(missingJob)
             }
         }

--- a/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsJobManager.groovy
@@ -52,6 +52,8 @@ class JenkinsJobManager {
         createMissingJobs(expectedJobs, currentTemplateDrivenJobNames, templateJobs)
         if (!noDelete) {
             deleteDeprecatedJobs(currentTemplateDrivenJobNames - expectedJobs.jobName)
+        } else {
+            println "Would have deleted: ${currentTemplateDrivenJobNames - expectedJobs.jobName}"
         }
         if (startExpected) {
             for (ConcreteJob expectedJob : expectedJobs) {

--- a/src/main/groovy/com/entagen/jenkins/Main.groovy
+++ b/src/main/groovy/com/entagen/jenkins/Main.groovy
@@ -15,6 +15,7 @@ class Main {
             c: [longOpt: 'print-config', required: false, args: 0, argName: 'printConfig', description:  "Check configuration - print out settings then exit - gradle flag -DprintConfig=true"],
             d: [longOpt: 'dry-run', required: false, args: 0, argName: 'dryRun', description:  "Dry run, don't actually modify, create, or delete any jobs, just print out what would happen - gradle flag: -DdryRun=true"],
             s: [longOpt: 'start-on-create', required: false, args: 0, argName: 'startOnCreate', description:  "When creating a new job, start it at once."],
+            x: [longOpt: 'start-expected', required: false, args: 0, argName: 'startExpected', description:  "Start jobs expected to exist after creation and deletion"],
             v: [longOpt: 'no-views', required: false, args: 0, argName: 'noViews', description: "Suppress view creation - gradle flag -DnoViews=true"],
             r: [longOpt: 'view-regex', required: false, args: 1, argName: 'viewRegex', description: "Supply a custom regex to be applied to any generated views, overriding the default template regex - gradle flag: -DviewRegex=<regex>"],
             k: [longOpt: 'no-delete', required: false, args: 0, argName: 'noDelete', description: "Do not delete (keep) branches and views - gradle flag -DnoDelete=true"],


### PR DESCRIPTION
I want to clone from a job in which a non existing branch is configured. Therefor this job cannot be executed itself and is therefor disabled. I made the cloned jobs enabled. I don't see why they should be disabled aswell.

I made a minor change to the regexp for the template job. I use the pattern <PROJECT>-<BRANCH>, but this did not match. I needed a double hyphen.

A build job was deleted which was not created by jenkins-build-per-branch. For a job to be deleted, its name should match the given branchNameRegex.

Added a startup argument to start all expected jobs, not only the created ones.