### PR TITLE
Don't try to start disabled jobs.

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
@@ -68,8 +68,11 @@ class JenkinsApi {
     }
 
     void startJob(ConcreteJob job) {
-        println "Starting job ${job.jobName}."
-        post('job/' + job.jobName + '/build')
+        String config = getJobConfig(job.jobName)
+        if (!config.contains("<disabled>true</disabled>")) {
+            println "Starting job ${job.jobName}."
+            post('job/' + job.jobName + '/build')
+        }
     }
 
     String configForMissingJob(ConcreteJob missingJob, List<TemplateJob> templateJobs) {


### PR DESCRIPTION
If a job is disabled and the flag 'startOnCreate' is set an error occured.