### PR TITLE
Ignore merge target when replacing template branch name.

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
@@ -76,7 +76,7 @@ class JenkinsApi {
         TemplateJob templateJob = missingJob.templateJob
         String config = getJobConfig(templateJob.jobName)
 
-        def ignoreTags = ["assignedNode"]
+        def ignoreTags = ["assignedNode", "mergeTarget"]
 
         // should work if there's a remote ("origin/master") or no remote (just "master")
         config = config.replaceAll("(\\p{Alnum}*[>/])(${templateJob.templateBranchName})<") { fullMatch, prefix, branchName ->


### PR DESCRIPTION
This allows you to have builds using `master` as a template, but still have
the build merge with master as part of the build config and not have that
get replaced with a command to merge it with itself.

It seems extremely unlikely that one would want to specify a merge command
in the template build that would merge the template branch into itself,
and expect that cloned builds would also be expected to merge into themselves.
Much more likely is that the merge command is added specifically so cloned
builds will attempt to merge into the template branch as part of the build
process to ensure the code that would be built / tested is able to be merged.
